### PR TITLE
persists darkModeEnabled to localStorage, adds test utilities

### DIFF
--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -1,14 +1,35 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, userEvent } from 'test-utilities';
 import App from './App';
-import { RecoilRoot } from 'recoil';
 
-test('renders content', () => {
-  render(
-    <RecoilRoot>
-      <App />
-    </RecoilRoot>
-  );
-  const contentElement = screen.getByText(/content/i);
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('renders Chris Anderson', () => {
+  render(<App />);
+  const contentElement = screen.getByText(/Chris Anderson/i);
   expect(contentElement).toBeInTheDocument();
+});
+
+describe('dark/light mode', () => {
+  test('dark mode is set by default', () => {
+    render(<App />);
+    const darkModeTogglebutton = screen.getByTestId('dark mode');
+    expect(darkModeTogglebutton).toBeTruthy();
+  });
+  test('user can toggle dark mode off', () => {
+    render(<App />);
+    const darkModeTogglebutton = screen.getByTestId('dark mode');
+    userEvent.click(darkModeTogglebutton);
+    expect(screen.queryByTestId('dark mode')).not.toBeTruthy();
+    expect(screen.getByTestId('light mode')).toBeTruthy();
+  });
+
+  test('selected value is saved to localStorage', () => {
+    render(<App />);
+    expect(localStorage.getItem('darkModeEnabled')).toBe('true');
+    userEvent.click(screen.getByTestId('dark mode'));
+    expect(localStorage.getItem('darkModeEnabled')).toBe('false');
+  });
 });

--- a/src/components/DarkModeToggleButton/DarkModeToggleButton.tsx
+++ b/src/components/DarkModeToggleButton/DarkModeToggleButton.tsx
@@ -5,9 +5,14 @@ import useDarkMode from 'styles/useDarkMode';
 function DarkModeToggleButton() {
   const { darkModeEnabled, toggleDarkMode } = useDarkMode();
   const ariaText = `enable ${darkModeEnabled ? 'light' : 'dark'} mode`;
-
+  const currentMode = `${darkModeEnabled ? 'dark' : 'light'} mode`;
   return (
-    <Button aria-labelledby={ariaText} onClick={toggleDarkMode} variant="icon">
+    <Button
+      data-testid={currentMode}
+      aria-labelledby={ariaText}
+      onClick={toggleDarkMode}
+      variant="icon"
+    >
       {darkModeEnabled ? <FiSun /> : <FiMoon />}
     </Button>
   );

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,11 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn()
+};
+
+//@ts-ignore
+global.localStorage = localStorageMock;

--- a/src/styles/useDarkMode.tsx
+++ b/src/styles/useDarkMode.tsx
@@ -15,8 +15,23 @@ const darkModeState = atom<boolean>({
 function useDarkMode() {
   const [darkModeEnabled, setDarkModeEnabled] = useRecoilState(darkModeState);
 
+  /** initialize value on mount */
+  React.useEffect(() => {
+    const currentLocalStorageValue = localStorage.getItem('darkModeEnabled');
+    if (typeof currentLocalStorageValue === 'string') {
+      setDarkModeEnabled(currentLocalStorageValue === 'true');
+    }
+
+    /** set localStorage value */
+    if (currentLocalStorageValue === null) {
+      localStorage.setItem('darkModeEnabled', 'true');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const toggleDarkMode = React.useCallback(() => {
     setDarkModeEnabled(!darkModeEnabled);
+    localStorage.setItem('darkModeEnabled', String(!darkModeEnabled));
   }, [darkModeEnabled, setDarkModeEnabled]);
 
   const theme: Theme = darkModeEnabled ? darkTheme : lightTheme;

--- a/src/test-utilities.tsx
+++ b/src/test-utilities.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MutableSnapshot, RecoilRoot } from 'recoil';
+
+const customRender = (
+  ui: React.ReactElement,
+  renderOptions: {
+    [key: string]: any;
+    initializeState?: (arg: MutableSnapshot) => void;
+  } = {}
+) => {
+  const { initializeState } = renderOptions;
+  const Wrapper: React.FunctionComponent = ({ children }) => (
+    <RecoilRoot initializeState={initializeState}>{children}</RecoilRoot>
+  );
+  return render(ui, {
+    wrapper: Wrapper,
+    ...renderOptions
+  });
+};
+
+// re-export everything
+export * from '@testing-library/react';
+
+// override render method
+export { customRender as render, userEvent };


### PR DESCRIPTION
- saves darkModeEnabled state to localStorage to persist user settings between sessions
- adds `localStorage` mock to setupTests
- adds `test-utilities` file with custom renderer with a RecoilRoot wrapper and exports testing libraries.